### PR TITLE
Use relative paths

### DIFF
--- a/lib/Dancer2/Plugin/Locale/Wolowitz.pm
+++ b/lib/Dancer2/Plugin/Locale/Wolowitz.pm
@@ -93,8 +93,12 @@ sub _path_directory_locale {
     my $dsl = shift;
 
     $conf ||= plugin_setting();
-    return $conf->{locale_path_directory}
-           // Dancer2::FileUtils::path($dsl->setting('appdir'), 'i18n');
+
+    my $dir = $conf->{locale_path_directory} // 'i18n';
+    unless (-d $dir) {
+        $dir = Dancer2::FileUtils::path($dsl->setting('appdir'), $dir);
+    }
+    return $dir;
 }
 
 sub _lang {


### PR DESCRIPTION
The config in the documentation was not working: when setting the path to a relative path,
is wasn't found. Now it looks in the app dir if the path isn't found as an absolute path.
